### PR TITLE
Add optional flag for registrar WHOIS server

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ been tested.
 | `w`, `age-warning`  | No       | 30      | No     | *positive whole number of days*                                         | The number of days remaining before domain expiration when a `WARNING` state is triggered.           |
 | `ll`, `log-level`   | No       | `info`  | No     | `disabled`, `panic`, `fatal`, `error`, `warn`, `info`, `debug`, `trace` | Log message priority filter. Log messages with a lower level are ignored.                            |
 | `d`, `domain`       | **Yes**  |         | No     | *domain name*                                                           | The name of the domain whose WHOIS records will be evaluated.                                        |
+| `s`, `server`       | No       |         | No     | *valid WHOIS server fqdn*                                               | The name of the optional domain registrar WHOIS server to use for queries.                           |
 
 ## Examples
 

--- a/cmd/check_whois/main.go
+++ b/cmd/check_whois/main.go
@@ -76,7 +76,14 @@ func main() {
 		Str("domain", cfg.Domain).
 		Logger()
 
-	whoisRaw, err := whois.Whois(cfg.Domain)
+	var whoisRaw string
+	var err error
+	switch {
+	case cfg.RegistrarServer != "":
+		whoisRaw, err = whois.Whois(cfg.Domain, cfg.RegistrarServer)
+	default:
+		whoisRaw, err = whois.Whois(cfg.Domain)
+	}
 	if err != nil {
 		log.Error().Err(err).Msg("failed to query WHOIS data")
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,6 +59,10 @@ type Config struct {
 	// Domain is the name of the domain whose WHOIS records will be evaluated.
 	Domain string
 
+	// RegistrarServer is the optional user-specified server to use for WHOIS
+	// lookups.
+	RegistrarServer string
+
 	// LoggingLevel is the supported logging level for this application.
 	LoggingLevel string
 

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -12,6 +12,7 @@ const myAppURL string = "https://github.com/atc0005/" + myAppName
 
 const (
 	domainFlagHelp                  string = "The name of the domain whose WHOIS records will be evaluated."
+	registrarServerFlagHelp         string = "The name of the optional domain registrar WHOIS server to use for queries."
 	versionFlagHelp                 string = "Whether to display application version and then immediately exit application."
 	logLevelFlagHelp                string = "Sets log level to one of disabled, panic, fatal, error, warn, info, debug or trace."
 	brandingFlagHelp                string = "Toggles emission of branding details with plugin status details. This output is disabled by default."
@@ -22,6 +23,7 @@ const (
 // Default flag settings if not overridden by user input
 const (
 	defaultDomain                string = ""
+	defaultRegistrarServer       string = ""
 	defaultLogLevel              string = "info"
 	defaultBranding              bool   = false
 	defaultDisplayVersionAndExit bool   = false

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -27,6 +27,9 @@ func (c *Config) handleFlagsConfig() {
 	flag.StringVar(&c.Domain, "d", defaultDomain, domainFlagHelp)
 	flag.StringVar(&c.Domain, "domain", defaultDomain, domainFlagHelp)
 
+	flag.StringVar(&c.RegistrarServer, "s", defaultRegistrarServer, registrarServerFlagHelp)
+	flag.StringVar(&c.RegistrarServer, "server", defaultRegistrarServer, registrarServerFlagHelp)
+
 	flag.BoolVar(&c.ShowVersion, "v", defaultDisplayVersionAndExit, versionFlagHelp)
 	flag.BoolVar(&c.ShowVersion, "version", defaultDisplayVersionAndExit, versionFlagHelp)
 


### PR DESCRIPTION
Add flag to specify registrar WHOIS server for domains where
the value is not well formed or (potentially?) missing.

fixes GH-15