### PR TITLE
Update CHANGELOG to list Windows builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The following types of changes will be recorded in this file:
 - Dependency updates
 - built using Go 1.16.7
   - Statically linked
+  - Windows (x86, x64)
   - Linux (x86, x64)
 
 ### Changed
@@ -50,6 +51,7 @@ The following types of changes will be recorded in this file:
 - Add new optional flag
 - built using Go 1.16.6
   - Statically linked
+  - Windows (x86, x64)
   - Linux (x86, x64)
 
 ### Added
@@ -63,6 +65,7 @@ The following types of changes will be recorded in this file:
 - Initial project release
 - built using Go 1.16.6
   - Statically linked
+  - Windows (x86, x64)
   - Linux (x86, x64)
 
 ### Added


### PR DESCRIPTION
Evidently when setting up this project I copied/pasted from another project of mine that doesn't provide Windows binaries.