### PR TITLE
Update github.com/likexian/whois to current master

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ go 1.19
 
 require (
 	github.com/atc0005/go-nagios v0.10.2
-	github.com/likexian/whois v1.14.2
+	github.com/likexian/whois v1.14.3-0.20221012013111-a48608e6097a
 	github.com/likexian/whois-parser v1.24.1
 	github.com/rs/zerolog v1.28.0
 

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5x
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/likexian/gokit v0.25.9 h1:rzSQ/dP7Qw+QUzSuWlrLF0AtZS3Di6uO5yWOKhx2Gk4=
 github.com/likexian/gokit v0.25.9/go.mod h1:oDDqJUcnnF9uAKuw54F7s6oEG+OJ7eallfDW2dq0A/o=
-github.com/likexian/whois v1.14.2 h1:RFtXK/2PSgl6vG1beXEwB2zCkwUWhy7A9zh258iQTqg=
-github.com/likexian/whois v1.14.2/go.mod h1:uEy9dUtYzjm9aSu9Tzbp+c1YEmyjQC90tYWudwvunFk=
+github.com/likexian/whois v1.14.3-0.20221012013111-a48608e6097a h1:K/QfmpWmyJQjNVKsPwoHc81Na9beJBQhhZAMMdrLJ7M=
+github.com/likexian/whois v1.14.3-0.20221012013111-a48608e6097a/go.mod h1:uBqrDy1FgZuHUAKWeoOuyq3zd1/BtslqnazV7tCT0sY=
 github.com/likexian/whois-parser v1.24.1 h1:UVV/A0hr2X4lM3rXUwjMX6x9MGfPJdJ4hCz8EjzSGNE=
 github.com/likexian/whois-parser v1.24.1/go.mod h1:fT0m/HCa4PXuR4ddA5PIE9V7gTWldeiMG/AHpeAhLtg=
 github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=

--- a/vendor/github.com/likexian/whois/whois.go
+++ b/vendor/github.com/likexian/whois/whois.go
@@ -227,6 +227,7 @@ func getServer(data string) (string, string) {
 			start += len(token)
 			end := strings.Index(data[start:], "\n")
 			server := strings.TrimSpace(data[start : start+end])
+			server = strings.TrimPrefix(server, "http:")
 			server = strings.TrimPrefix(server, "whois:")
 			server = strings.TrimPrefix(server, "rwhois:")
 			server = strings.Trim(server, "/")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -5,7 +5,7 @@ github.com/atc0005/go-nagios
 ## explicit; go 1.18
 github.com/likexian/gokit/assert
 github.com/likexian/gokit/xslice
-# github.com/likexian/whois v1.14.2
+# github.com/likexian/whois v1.14.3-0.20221012013111-a48608e6097a
 ## explicit; go 1.18
 github.com/likexian/whois
 # github.com/likexian/whois-parser v1.24.1


### PR DESCRIPTION
Update from v1.14.2 to v1.14.3-0.20221012013111-a48608e6097a to pull in hotfix for `Registrar WHOIS Server` fields containing a (presumably invalid) `http://` prefix for listed WHOIS server.

fixes GH-115