### PR TITLE
Update nagios library usage

### DIFF
--- a/cmd/check_whois/main_test.go
+++ b/cmd/check_whois/main_test.go
@@ -1,0 +1,56 @@
+// Copyright 2022 Adam Chalkley
+//
+// https://github.com/atc0005/check-whois
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/atc0005/go-nagios"
+)
+
+// TestEmptyClientPerfDataAndConstructedPluginProducesDefaultTimeMetric
+// asserts that omitted performance data from client code produces a default
+// time metric when using the Plugin constructor.
+func TestEmptyClientPerfDataAndConstructedPluginProducesDefaultTimeMetric(t *testing.T) {
+	t.Parallel()
+
+	// Setup Plugin type the same way that client code using the
+	// constructor would.
+	plugin := nagios.NewPlugin()
+
+	// Performance Data metrics are not emitted if we do not supply a
+	// ServiceOutput value.
+	plugin.ServiceOutput = "TacoTuesday"
+
+	var outputBuffer strings.Builder
+
+	plugin.SetOutputTarget(&outputBuffer)
+
+	// os.Exit calls break tests
+	plugin.SkipOSExit()
+
+	// Process exit state, emit output to our output buffer.
+	plugin.ReturnCheckResults()
+
+	want := fmt.Sprintf(
+		"%s | %s",
+		plugin.ServiceOutput,
+		"'time'=",
+	)
+
+	got := outputBuffer.String()
+
+	if !strings.Contains(got, want) {
+		t.Errorf("ERROR: Plugin output does not contain the expected time metric")
+		t.Errorf("\nwant %q\ngot %q", want, got)
+	} else {
+		t.Logf("OK: Emitted performance data contains the expected time metric.")
+	}
+}


### PR DESCRIPTION
- Allow the new nagios package functionality to handle tracking and emitting the `time` metric automatically at plugin completion
- Add test from the atc0005/go-nagios project to assert that the inherited/automatic `time` metric provided by the nagios package is emitted at plugin completion
  - since plugins in this project no longer explicitly track this performance data metric this test asserts that the nagios package continues to provide it
- Update nagios library usage to reflect dep changes
  - use nagios.NewPlugin constructor in place of manual initialization
  - swap retired ExitState type for new Plugin type

refs GH-128