### PR TITLE
Remove `Push Validation` workflow status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Go-based tooling to monitor WHOIS records.
 [![go.mod Go version](https://img.shields.io/github/go-mod/go-version/atc0005/check-whois)](https://github.com/atc0005/check-whois)
 [![Lint and Build](https://github.com/atc0005/check-whois/actions/workflows/lint-and-build.yml/badge.svg)](https://github.com/atc0005/check-whois/actions/workflows/lint-and-build.yml)
 [![Project Analysis](https://github.com/atc0005/check-whois/actions/workflows/project-analysis.yml/badge.svg)](https://github.com/atc0005/check-whois/actions/workflows/project-analysis.yml)
-[![Push Validation](https://github.com/atc0005/check-whois/actions/workflows/push-validation.yml/badge.svg)](https://github.com/atc0005/check-whois/actions/workflows/push-validation.yml)
 
 <!-- omit in toc -->
 ## Table of Contents


### PR DESCRIPTION
This workflow was removed recently, but the "status badge" was unintentionally left behind in the README file.

refs atc0005/shared-project-resources#63
refs atc0005/go-ci#847