### PR TITLE
Use UNKNOWN state for invalid command-line options

### DIFF
--- a/cmd/check_whois/main.go
+++ b/cmd/check_whois/main.go
@@ -43,10 +43,10 @@ func main() {
 		zlog.Err(cfgErr).Msg("Error initializing application")
 		plugin.ServiceOutput = fmt.Sprintf(
 			"%s: Error initializing application",
-			nagios.StateCRITICALLabel,
+			nagios.StateUNKNOWNLabel,
 		)
 		plugin.AddError(cfgErr)
-		plugin.ExitStatusCode = nagios.StateCRITICALExitCode
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
 
 		return
 	}


### PR DESCRIPTION
Update handling of invalid flags/values to use an UNKNOWN exit state to comply with Nagios Plugin Guideline
recommendations.

refs GH-152
refs atc0005/todo#55
refs https://nagios-plugins.org/doc/guidelines.html