### PR TITLE
Use UNKNOWN state for fetching & parsing failures

### DIFF
--- a/cmd/check_whois/main.go
+++ b/cmd/check_whois/main.go
@@ -86,10 +86,10 @@ func main() {
 		plugin.AddError(err)
 		plugin.ServiceOutput = fmt.Sprintf(
 			"%s: Error fetching WHOIS data for %s domain",
-			nagios.StateCRITICALLabel,
+			nagios.StateUNKNOWNLabel,
 			cfg.Domain,
 		)
-		plugin.ExitStatusCode = nagios.StateCRITICALExitCode
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
 
 		return
 
@@ -102,10 +102,10 @@ func main() {
 		plugin.AddError(err)
 		plugin.ServiceOutput = fmt.Sprintf(
 			"%s: Error parsing WHOIS data for %s domain",
-			nagios.StateCRITICALLabel,
+			nagios.StateUNKNOWNLabel,
 			cfg.Domain,
 		)
-		plugin.ExitStatusCode = nagios.StateCRITICALExitCode
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
 
 		return
 
@@ -118,10 +118,10 @@ func main() {
 		plugin.AddError(err)
 		plugin.ServiceOutput = fmt.Sprintf(
 			"%s: Error parsing WhoisInfo data for %s domain",
-			nagios.StateCRITICALLabel,
+			nagios.StateUNKNOWNLabel,
 			cfg.Domain,
 		)
-		plugin.ExitStatusCode = nagios.StateCRITICALExitCode
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
 
 		return
 


### PR DESCRIPTION
Update handling of fetching/parsing failures to use an UNKNOWN exit state to comply with Nagios Plugin Guideline
recommendations.

refs GH-152
refs https://nagios-plugins.org/doc/guidelines.html