### PR TITLE
Disable depguard linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,8 @@ issues:
 
 linters:
   enable:
-    - depguard
+    # https://github.com/atc0005/go-ci/issues/1024
+    # - depguard
     - dogsled
     - dupl
     - goconst


### PR DESCRIPTION
By having v2 of the linter enabled without an explicitly defined configuration the linter assumes that *no* non-stdlib packages are permitted.

We disable the linter because we do not have any need to define permit/deny lists for packages used by this project at this time.

refs atc0005/go-ci#1024