### PR TITLE
Add domain performance data metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Go-based tooling to monitor WHOIS records.
 - [Project home](#project-home)
 - [Overview](#overview)
   - [`check_whois`](#check_whois)
+    - [Performance Data](#performance-data)
 - [Features](#features)
 - [Changelog](#changelog)
 - [Requirements](#requirements)
@@ -57,6 +58,26 @@ The output for this application is designed to provide the one-line summary
 needed by Nagios for quick identification of a problem while providing longer,
 more detailed information for use in email and Teams notifications
 ([atc0005/send2teams](https://github.com/atc0005/send2teams)).
+
+#### Performance Data
+
+Initial support has been added for emitting Performance Data / Metrics, but
+refinement suggestions are welcome.
+
+Consult the tables below for the metrics implemented thus far.
+
+Please add to an existing
+[Discussion](https://github.com/atc0005/check-whois/discussions) thread
+(if applicable) or [open a new
+one](https://github.com/atc0005/check-whois/discussions/new) with any
+feedback that you may have. Thanks in advance!
+
+| Emitted Performance Data / Metric | Unit of Measurement | Meaning                         |
+| --------------------------------- | ------------------- | ------------------------------- |
+| `time`                            | seconds             | Runtime for plugin              |
+| `expiration`                      | days                | Until domain expires.           |
+| `since_update`                    | days                | Since domain was last updated.  |
+| `since_creation`                  | days                | Since domain was first created. |
 
 ## Features
 

--- a/cmd/check_whois/main.go
+++ b/cmd/check_whois/main.go
@@ -129,6 +129,41 @@ func main() {
 
 	}
 
+	pd, perfDataErr := getPerfData(d, cfg.AgeCritical, cfg.AgeWarning)
+	if perfDataErr != nil {
+		log.Error().
+			Err(perfDataErr).
+			Msg("failed to generate performance data")
+
+		// Surface the error in plugin output.
+		plugin.AddError(perfDataErr)
+
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
+		plugin.ServiceOutput = fmt.Sprintf(
+			"%s: Failed to generate performance data metrics",
+			nagios.StateUNKNOWNLabel,
+		)
+
+		return
+	}
+
+	if err := plugin.AddPerfData(false, pd...); err != nil {
+		log.Error().
+			Err(err).
+			Msg("failed to add performance data")
+
+		// Surface the error in plugin output.
+		plugin.AddError(err)
+
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
+		plugin.ServiceOutput = fmt.Sprintf(
+			"%s: Failed to process performance data metrics",
+			nagios.StateUNKNOWNLabel,
+		)
+
+		return
+	}
+
 	switch {
 
 	case d.IsExpired():

--- a/cmd/check_whois/perfdata.go
+++ b/cmd/check_whois/perfdata.go
@@ -1,0 +1,59 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/check-whois
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/atc0005/check-whois/internal/domain"
+	"github.com/atc0005/go-nagios"
+)
+
+// getPerfData generates performance data metrics from the given domain
+// metadata age thresholds. An error is returned if any are encountered while
+// gathering metrics or if invalid domain metadata is provided.
+func getPerfData(d *domain.Metadata, ageCritical int, ageWarning int) ([]nagios.PerformanceData, error) {
+
+	var expires int
+	if daysToExpiration, err := domain.UntilExpiration(d); err == nil {
+		expires = daysToExpiration
+	}
+
+	var updated int
+	if daysSinceUpdate, err := domain.SinceUpdate(d); err == nil {
+		updated = daysSinceUpdate
+	}
+
+	var created int
+	if daysSinceCreation, err := domain.SinceCreation(d); err == nil {
+		created = daysSinceCreation
+	}
+
+	pd := []nagios.PerformanceData{
+		{
+			Label:             "expires",
+			Value:             fmt.Sprintf("%d", expires),
+			UnitOfMeasurement: "d",
+			Warn:              fmt.Sprintf("%d", ageWarning),
+			Crit:              fmt.Sprintf("%d", ageCritical),
+		},
+		{
+			Label:             "since_update",
+			Value:             fmt.Sprintf("%d", updated),
+			UnitOfMeasurement: "d",
+		},
+		{
+			Label:             "since_creation",
+			Value:             fmt.Sprintf("%d", created),
+			UnitOfMeasurement: "d",
+		},
+	}
+
+	return pd, nil
+
+}


### PR DESCRIPTION
Add performance data metrics to track days until upcoming domain expiration, last update and days since creation:

- `expires`
- `since_update`
- `since_creation`

As part of providing these performance data metrics various helper functions were added:

- `main.getPerfData`
- `domain.UntilExpiration`
- `domain.SinceUpdate`
- `domain.SinceCreation`

The README file has been updated to list the purpose of each performance data metric.

A failure to collect performance data is emitted as an error message and recorded in the plugin's error collection (for display in `LongServiceOutput`).

- fixes GH-228