### PR TITLE
Fix errcheck linting errors

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,8 +35,8 @@ var Usage = func() {
 	// `--help` flag and have it display within the Admin web UI.
 	flag.CommandLine.SetOutput(os.Stdout)
 
-	fmt.Fprintln(flag.CommandLine.Output(), "\n"+Version()+"\n")
-	fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
+	_, _ = fmt.Fprintln(flag.CommandLine.Output(), "\n"+Version()+"\n")
+	_, _ = fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
 	flag.PrintDefaults()
 }
 

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -195,7 +195,7 @@ func (m Metadata) Report() string {
 
 	var summary strings.Builder
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&summary,
 		"WHOIS metadata for %q domain:%s%s",
 		m.Name,
@@ -203,49 +203,49 @@ func (m Metadata) Report() string {
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&summary,
 		"* Status: %s%s",
 		domainStatus(m),
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&summary,
 		"* Creation Date: %v%s",
 		m.CreatedDate.Format(DomainDateLayout),
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&summary,
 		"* Updated Date: %v%s",
 		m.UpdatedDate.Format(DomainDateLayout),
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&summary,
 		"* Expiration Date: %v%s",
 		m.ExpirationDate.Format(DomainDateLayout),
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&summary,
 		"* Registrar Name: %v%s",
 		registrarName(m),
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&summary,
 		"* Registrant Name: %v%s",
 		registrantName(m),
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&summary,
 		"* Registrant Email: %v%s",
 		registrantEmail(m),


### PR DESCRIPTION
Resolve `return value of fmt.Fprintf is not checked`` errors by
explicitly discarding return values (potential error, bytes written)
since we do not need them and the potential for failure (in this
particular use case) is *highly* unlikely.
